### PR TITLE
toTask, send, andThen

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,32 @@
+BSD 3-Clause License
+
+Copyright (c) 2017-present, Coury Ditch and Nick Miller
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+
+    * Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      disclaimer in the documentation and/or other materials provided
+      with the distribution.
+
+    * Neither the name of the copyright holder nor the names of other
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/elm-package.json
+++ b/elm-package.json
@@ -6,8 +6,7 @@
     "source-directories": [
         ".",
         "./src",
-        "./sandbox",
-        "./examples"
+        "./sandbox"
     ],
     "exposed-modules": [],
     "native-modules": true,

--- a/examples/Main.elm
+++ b/examples/Main.elm
@@ -94,10 +94,10 @@ update : Msg -> Model -> ( Model, Cmd Msg )
 update msg model =
     case msg of
         GetBlockNumber ->
-            model ! [ getBlockNumber GetBlockNumberResponse ]
+            model ! [ Web3.send GetBlockNumberResponse getBlockNumber ]
 
-        GetBlock int ->
-            model ! [ getBlock GetBlockResponse int ]
+        GetBlock n ->
+            model ! [ Web3.send GetBlockResponse (getBlock n) ]
 
         GetBlockNumberResponse response ->
             case response of

--- a/src/Native/Web3.js
+++ b/src/Native/Web3.js
@@ -9,7 +9,7 @@ var _cmditch$elm_web3$Native_Web3 = function() {
       undefinedResposnse: "Web3 responded with undefined."
     }
 
-    function toTask(data) {
+    function toTask(request) {
         return _elm_lang$core$Native_Scheduler.nativeBinding(function(callback) {
             try {
                 var f = eval("web3." + request.func);

--- a/src/Native/Web3.js
+++ b/src/Native/Web3.js
@@ -4,17 +4,17 @@
 
 var _cmditch$elm_web3$Native_Web3 = function() {
 
-    function request(data) {
+    function toTask(request) {
         return _elm_lang$core$Native_Scheduler.nativeBinding(function(callback) {
             try {
-                var f = eval("web3." + data.func);
+                var f = eval("web3." + request.func);
                 f.apply(null,
-                    data.args.concat( (e, r) => {
-                        if (e !== null) {
+                    request.args.concat( (e, r) => {
+                        if (e !== null && e !== undefined) {
                             return callback(_elm_lang$core$Native_Scheduler.fail({ ctor: 'Error', _0: e.toString() }));
                         }
 
-                        var result = data.expect.responseToResult(JSON.stringify(r));
+                        var result = request.expect.responseToResult(JSON.stringify(r));
                         return callback(_elm_lang$core$Native_Scheduler.succeed(result._0));
                     }
                 ));
@@ -32,7 +32,7 @@ var _cmditch$elm_web3$Native_Web3 = function() {
     }
 
     return {
-        request: request,
+        toTask: toTask,
         expectStringResponse: expectStringResponse
     };
 

--- a/src/Web3.elm
+++ b/src/Web3.elm
@@ -2,18 +2,35 @@ module Web3
     exposing
         ( Request
         , Error(..)
+        , toTask
+        , send
         )
 
+{-| Web3
+-}
+
 import Native.Web3
-import Web3.Internal exposing (Expect)
+import Task exposing (Task)
+import Web3.Internal
 
 
+{-| Request
+Represents a web3 request expecting a response of type `a`.
+Masks the internal request structure.
+-}
 type alias Request a =
-    { func : String
-    , args : List String
-    , expect : Expect a
-    }
+    Web3.Internal.Request a
 
 
 type Error
     = Error String
+
+
+toTask : Request a -> Task Error a
+toTask (Web3.Internal.Request request) =
+    Native.Web3.toTask request
+
+
+send : (Result Error a -> msg) -> Request a -> Cmd msg
+send msg request =
+    Task.attempt msg (toTask request)

--- a/src/Web3/Eth.elm
+++ b/src/Web3/Eth.elm
@@ -4,32 +4,41 @@ module Web3.Eth
         , getBlock
         )
 
-import Web3 exposing (Error)
+{-| Web3.Eth
+-}
+
+import Web3 exposing (Error, Request)
 import Web3.Eth.Types exposing (Block)
 import Web3.Eth.Decoders exposing (blockDecoder)
-import Web3.Internal exposing (expectInt, expectJson)
-import Json.Encode exposing (list, int)
+import Web3.Internal as Internal exposing (Expect, expectInt, expectJson)
+import Json.Encode as Encode
 import Native.Web3
 import Task
 
 
-getBlockNumber : (Result Error Int -> msg) -> Cmd msg
-getBlockNumber msg =
-    Task.attempt msg
-        (Native.Web3.request
-            { func = "eth.getBlockNumber"
-            , args = list []
-            , expect = expectInt
-            }
-        )
+request :
+    { func : String
+    , args : Encode.Value
+    , expect : Expect a
+    }
+    -> Request a
+request =
+    Internal.Request
 
 
-getBlock : (Result Error Block -> msg) -> Int -> Cmd msg
-getBlock msg blockNum =
-    Task.attempt msg
-        (Native.Web3.request
-            { func = "eth.getBlock"
-            , args = list [ int blockNum ]
-            , expect = expectJson blockDecoder
-            }
-        )
+getBlockNumber : Request Int
+getBlockNumber =
+    request
+        { func = "eth.getBlockNumber"
+        , args = Encode.list []
+        , expect = expectInt
+        }
+
+
+getBlock : Int -> Request Block
+getBlock blockNum =
+    request
+        { func = "eth.getBlock"
+        , args = Encode.list [ Encode.int blockNum ]
+        , expect = expectJson blockDecoder
+        }

--- a/src/Web3/Eth/Types.elm
+++ b/src/Web3/Eth/Types.elm
@@ -1,5 +1,8 @@
 module Web3.Eth.Types exposing (..)
 
+{-| Web3.Eth.Types
+-}
+
 import BigInt exposing (BigInt)
 
 

--- a/src/Web3/Internal.elm
+++ b/src/Web3/Internal.elm
@@ -1,12 +1,26 @@
 module Web3.Internal
     exposing
         ( Expect
+        , Request(..)
+        , RawRequest
         , expectStringResponse
         , expectInt
         , expectJson
         )
 
 import Json.Decode as Decode exposing (Decoder)
+import Json.Encode as Encode
+
+
+type Request a
+    = Request (RawRequest a)
+
+
+type alias RawRequest a =
+    { func : String
+    , args : Encode.Value
+    , expect : Expect a
+    }
 
 
 type alias Response =


### PR DESCRIPTION
* Implements the last of the convenience functions from `elm-lang/http` 
  * tasks are now chainable!
* adds BSD3 license (same as elm's)

### Next step

I think this work sets the stage well to start implementing other "read-only" functions from web3. There will very likely be other avenues into the native module to account for the differet request semantics, but this should work for a lot of functions.

### Issues encountered

It seems that metamask and infura return different fields in their responses, so decoders will need to be beefed-up to handle changing field names (_why two nodes on the same f'ing chain don't return the same structures? no clue_)