### PR TITLE
Cleaned up API. No more toTask in the update function

### DIFF
--- a/examples/Main.elm
+++ b/examples/Main.elm
@@ -6,7 +6,6 @@ import Html.Events exposing (onClick, onInput)
 import Web3 exposing (Error(..), toTask)
 import Web3.Eth exposing (getBlockNumber, getBlock)
 import Web3.Eth.Types exposing (Block)
-import BigInt
 
 
 main : Program Never Model Msg
@@ -76,8 +75,7 @@ update msg model =
             model
                 ! [ Task.attempt LatestResponse
                         (getBlockNumber
-                            |> toTask
-                            |> Task.andThen (\latest -> getBlock latest |> toTask)
+                            |> Task.andThen (\latest -> getBlock latest)
                         )
                   ]
 

--- a/src/Web3.elm
+++ b/src/Web3.elm
@@ -1,7 +1,6 @@
 module Web3
     exposing
-        ( Request
-        , Error(..)
+        ( Error(..)
         , toTask
         , send
         )
@@ -11,15 +10,7 @@ module Web3
 
 import Native.Web3
 import Task exposing (Task)
-import Web3.Internal
-
-
-{-| Request
-Represents a web3 request expecting a response of type `a`.
-Masks the internal request structure.
--}
-type alias Request a =
-    Web3.Internal.Request a
+import Web3.Internal exposing (Request)
 
 
 type Error
@@ -28,7 +19,7 @@ type Error
 
 
 toTask : Request a -> Task Error a
-toTask (Web3.Internal.Request request) =
+toTask request =
     Native.Web3.toTask request
 
 

--- a/src/Web3/Eth.elm
+++ b/src/Web3/Eth.elm
@@ -7,38 +7,27 @@ module Web3.Eth
 {-| Web3.Eth
 -}
 
-import Web3 exposing (Error, Request)
+import Web3 exposing (Error, toTask)
 import Web3.Eth.Types exposing (Block)
 import Web3.Eth.Decoders exposing (blockDecoder)
-import Web3.Internal as Internal exposing (Expect, expectInt, expectJson)
+import Web3.Internal as Internal exposing (Expect, Request, expectInt, expectJson)
 import Json.Encode as Encode
-import Native.Web3
-import Task
+import Task exposing (Task)
 
 
-request :
-    { func : String
-    , args : Encode.Value
-    , expect : Expect a
-    }
-    -> Request a
-request =
-    Internal.Request
-
-
-getBlockNumber : Request Int
+getBlockNumber : Task Error Int
 getBlockNumber =
-    request
-        { func = "eth.getBlockNumber"
-        , args = Encode.list []
-        , expect = expectInt
-        }
+    { func = "eth.getBlockNumber"
+    , args = Encode.list []
+    , expect = expectInt
+    }
+        |> toTask
 
 
-getBlock : Int -> Request Block
+getBlock : Int -> Task Error Block
 getBlock blockNum =
-    request
-        { func = "eth.getBlock"
-        , args = Encode.list [ Encode.int blockNum ]
-        , expect = expectJson blockDecoder
-        }
+    { func = "eth.getBlock"
+    , args = Encode.list [ Encode.int blockNum ]
+    , expect = expectJson blockDecoder
+    }
+        |> toTask

--- a/src/Web3/Internal.elm
+++ b/src/Web3/Internal.elm
@@ -1,8 +1,7 @@
 module Web3.Internal
     exposing
         ( Expect
-        , Request(..)
-        , RawRequest
+        , Request
         , expectStringResponse
         , expectInt
         , expectJson
@@ -12,11 +11,7 @@ import Json.Decode as Decode exposing (Decoder)
 import Json.Encode as Encode
 
 
-type Request a
-    = Request (RawRequest a)
-
-
-type alias RawRequest a =
+type alias Request a =
     { func : String
     , args : Encode.Value
     , expect : Expect a


### PR DESCRIPTION
Removed the need to add `toTask` boilerplate in user's update function. Also removed `RawRequest` type, as there is no need at this time to expose any implementation details or 'config functions' (e.g., [see here](https://github.com/cmditch/elm-mdl-sortable-table/blob/master/src/Material/Table/Sortable.elm#L98))