### PR TITLE
Sync as Result

### DIFF
--- a/examples/lightbox/LightBox.elm
+++ b/examples/lightbox/LightBox.elm
@@ -51,7 +51,6 @@ add_ address a b =
         { func = Contract.call lightBoxAbi_ address "add_"
         , args = Encode.list [ Encode.int a, Encode.int b ]
         , expect = expectJson bigIntDecoder
-        , callType = Async
         }
 
 
@@ -61,7 +60,6 @@ mutateAdd address n =
         { func = Contract.call lightBoxAbi_ address "mutateAdd"
         , args = Encode.list [ Encode.int n, encodeTxParams defaultTxParams ]
         , expect = expectJson txIdDecoder
-        , callType = Async
         }
 
 

--- a/examples/lightbox/Main.elm
+++ b/examples/lightbox/Main.elm
@@ -254,7 +254,7 @@ update msg model =
     in
         case msg of
             SetCoinbase address ->
-                case address of
+                case Result.andThen Web3.toChecksumAddress address of
                     Err err ->
                         handleError model err
 

--- a/src/Native/Web3.js
+++ b/src/Native/Web3.js
@@ -67,6 +67,7 @@ var _cmditch$elm_web3$Native_Web3 = function() {
 
 
     function toResult(request) {
+        console.log("toResult: ", request);
         try
         {
             var web3Response = eval("web3." + request.func).apply(null, request.args);

--- a/src/Web3.elm
+++ b/src/Web3.elm
@@ -2,6 +2,7 @@ module Web3
     exposing
         ( Retry
         , reset
+        , isAddress
         , toChecksumAddress
         , toTask
         , toResult

--- a/src/Web3/Eth.elm
+++ b/src/Web3/Eth.elm
@@ -28,21 +28,19 @@ import BigInt exposing (BigInt)
 
 setDefaultAccount : Address -> Task Error Address
 setDefaultAccount (Address address) =
-    Web3.setOrGet
+    Web3.setOrGet Setter
         { func = "eth.defaultAccount"
         , args = Encode.list [ Encode.string address ]
         , expect = expectJson addressDecoder
-        , callType = Setter
         }
 
 
 getDefaultAccount : Task Error Address
 getDefaultAccount =
-    Web3.setOrGet
+    Web3.setOrGet Getter
         { func = "eth.defaultAccount"
         , args = Encode.list []
         , expect = expectJson addressDecoder
-        , callType = Getter
         }
 
 
@@ -52,7 +50,6 @@ getSyncing =
         { func = "eth.getSyncing"
         , args = Encode.list []
         , expect = expectJson (Decode.maybe syncStatusDecoder)
-        , callType = Async
         }
 
 
@@ -79,7 +76,6 @@ getCoinbase =
         { func = "eth.getCoinbase"
         , args = Encode.list []
         , expect = expectJson addressDecoder
-        , callType = Async
         }
 
 
@@ -94,7 +90,6 @@ getMining =
         { func = "eth.getMining"
         , args = Encode.list []
         , expect = expectBool
-        , callType = Async
         }
 
 
@@ -104,7 +99,6 @@ getHashrate =
         { func = "eth.getHashrate"
         , args = Encode.list []
         , expect = expectInt
-        , callType = Async
         }
 
 
@@ -114,7 +108,6 @@ getGasPrice =
         { func = "eth.getGasPrice"
         , args = Encode.list []
         , expect = expectBigInt
-        , callType = Async
         }
 
 
@@ -124,7 +117,6 @@ getAccounts =
         { func = "eth.getAccounts"
         , args = Encode.list []
         , expect = expectJson (Decode.list addressDecoder)
-        , callType = Async
         }
 
 
@@ -139,7 +131,6 @@ getBlockNumber =
         { func = "eth.getBlockNumber"
         , args = Encode.list []
         , expect = expectInt
-        , callType = Async
         }
 
 
@@ -149,7 +140,6 @@ getBalance (Address address) =
         { func = "eth.getBalance"
         , args = Encode.list [ Encode.string address ]
         , expect = expectBigInt
-        , callType = Async
         }
 
 
@@ -164,7 +154,6 @@ getStorageAtBlock blockId (Address address) position =
         { func = "eth.getStorageAt"
         , args = Encode.list [ Encode.string address, Encode.int position, getBlockIdValue blockId ]
         , expect = expectJson hexDecoder
-        , callType = Async
         }
 
 
@@ -179,7 +168,6 @@ getCodeAtBlock blockId (Address address) =
         { func = "eth.getStorageAt"
         , args = Encode.list [ Encode.string address, getBlockIdValue blockId ]
         , expect = expectJson bytesDecoder
-        , callType = Async
         }
 
 
@@ -189,7 +177,6 @@ getBlock blockId =
         { func = "eth.getBlock"
         , args = Encode.list [ getBlockIdValue blockId, Encode.bool False ]
         , expect = expectJson blockDecoder
-        , callType = Async
         }
 
 
@@ -203,7 +190,6 @@ getBlockTxObjs blockId =
         { func = "eth.getBlock"
         , args = Encode.list [ getBlockIdValue blockId, Encode.bool True ]
         , expect = expectJson blockTxObjDecoder
-        , callType = Async
         }
 
 
@@ -213,7 +199,6 @@ getBlockTransactionCount blockId =
         { func = "eth.getBlockTransactionCount"
         , args = Encode.list [ getBlockIdValue blockId ]
         , expect = expectInt
-        , callType = Async
         }
 
 
@@ -223,7 +208,6 @@ getUncle blockId index =
         { func = "eth.getUncle"
         , args = Encode.list [ getBlockIdValue blockId, Encode.int index, Encode.bool False ]
         , expect = expectJson blockDecoder
-        , callType = Async
         }
 
 
@@ -233,7 +217,6 @@ getUncleTxObjs blockId index =
         { func = "eth.getUncle"
         , args = Encode.list [ getBlockIdValue blockId, Encode.int index, Encode.bool True ]
         , expect = expectJson blockTxObjDecoder
-        , callType = Async
         }
 
 
@@ -243,7 +226,6 @@ getTransaction (TxId txId) =
         { func = "eth.getTransaction"
         , args = Encode.list [ Encode.string txId ]
         , expect = expectJson txObjDecoder
-        , callType = Async
         }
 
 
@@ -253,7 +235,6 @@ getTransactionFromBlock blockId index =
         { func = "eth.getTransactionFromBlock"
         , args = Encode.list [ getBlockIdValue blockId, Encode.int index ]
         , expect = expectJson txObjDecoder
-        , callType = Async
         }
 
 
@@ -263,7 +244,6 @@ getTransactionReceipt (TxId txId) =
         { func = "eth.getTransactionReceipt"
         , args = Encode.list [ Encode.string txId ]
         , expect = expectJson txReceiptDecoder
-        , callType = Async
         }
 
 
@@ -278,7 +258,6 @@ getTransactionCountAtBlock blockId (Address address) =
         { func = "eth.getTransactionCount"
         , args = Encode.list [ Encode.string address, getBlockIdValue blockId ]
         , expect = expectInt
-        , callType = Async
         }
 
 
@@ -288,7 +267,6 @@ sendTransaction txParams =
         { func = "eth.sendTransaction"
         , args = Encode.list [ encodeTxParams txParams ]
         , expect = expectJson txIdDecoder
-        , callType = Async
         }
 
 
@@ -298,7 +276,6 @@ sendRawTransaction (Bytes signedData) =
         { func = "eth.sendRawTransaction"
         , args = Encode.list [ Encode.string signedData ]
         , expect = expectJson txIdDecoder
-        , callType = Async
         }
 
 
@@ -308,7 +285,6 @@ sign (Address address) (Bytes bytes) =
         { func = "eth.sign"
         , args = Encode.list [ Encode.string address, Encode.string bytes ]
         , expect = expectJson bytesDecoder
-        , callType = Async
         }
 
 
@@ -323,7 +299,6 @@ callAtBlock blockId txParams =
         { func = "eth.call"
         , args = Encode.list [ encodeTxParams txParams, getBlockIdValue blockId ]
         , expect = expectJson txIdDecoder
-        , callType = Async
         }
 
 
@@ -333,7 +308,6 @@ estimateGas txParams =
         { func = "eth.estimateGas"
         , args = Encode.list [ encodeTxParams txParams ]
         , expect = expectInt
-        , callType = Async
         }
 
 

--- a/src/Web3/Eth/Contract.elm
+++ b/src/Web3/Eth/Contract.elm
@@ -46,7 +46,6 @@ get argDecoder { abi, address, argsFilter, filterParams, eventName } =
         { func = contractFuncHelper abi address eventName
         , args = Encode.list [ argsFilter, filterParams ]
         , expect = expectJson (Decode.list argDecoder)
-        , callType = Async
         }
 
 
@@ -76,6 +75,5 @@ pollContract retryParams (TxId txId) =
         { func = "eth.getTransactionReceipt"
         , args = Encode.list [ Encode.string txId ]
         , expect = expectJson contractInfoDecoder
-        , callType = Async
         }
         |> Web3.retry retryParams

--- a/src/Web3/Internal.elm
+++ b/src/Web3/Internal.elm
@@ -15,7 +15,6 @@ type alias Request a =
     { func : String
     , args : Encode.Value
     , expect : Expect a
-    , callType : CallType
     }
 
 

--- a/src/Web3/Net.elm
+++ b/src/Web3/Net.elm
@@ -31,7 +31,6 @@ getListening =
         { func = "net.getListening"
         , args = Encode.list []
         , expect = expectBool
-        , callType = Async
         }
 
 
@@ -46,5 +45,4 @@ getPeerCount =
         { func = "net.getPeerCount"
         , args = Encode.list []
         , expect = expectInt
-        , callType = Async
         }

--- a/src/Web3/Types.elm
+++ b/src/Web3/Types.elm
@@ -214,7 +214,5 @@ type Expect a
 
 
 type CallType
-    = Sync
-    | Async
-    | Setter
+    = Setter
     | Getter

--- a/src/Web3/Version.elm
+++ b/src/Web3/Version.elm
@@ -25,13 +25,12 @@ import Web3.Decoders exposing (expectString, expectJson, hexDecoder)
     Web3.Version.api == Ok "0.19.0"
 
 -}
-api : Task Error String
+api : Result Error String
 api =
-    Web3.toTask
+    Web3.toResult
         { func = "version.api"
         , args = Encode.list []
         , expect = expectString
-        , callType = Sync
         }
 
 
@@ -46,7 +45,6 @@ getNode =
         { func = "version.getNode"
         , args = Encode.list []
         , expect = expectString
-        , callType = Async
         }
 
 
@@ -61,7 +59,6 @@ getNetwork =
         { func = "version.getNetwork"
         , args = Encode.list []
         , expect = expectString
-        , callType = Async
         }
 
 
@@ -78,7 +75,6 @@ getEthereum =
         { func = "version.getEthereum"
         , args = Encode.list []
         , expect = expectJson hexDecoder
-        , callType = Async
         }
 
 


### PR DESCRIPTION
Yummy deletions.
  - Added Native.Web3.toResult for synchronous functions. 
  - Cleaned up toTask. No more Sync/Async conditional.
  - Removed Sync/Async from CallType and and Request types. Cleaned up all functions accordingly.

**NOTE** : Right now `Web3.toResult` returns a `Result Web3.Error a`, forcing the user to pattern match the Result as well as the Web3.Error type. I did this so the types would match up when using Result.andThen. 

It's still not clear whether we'll need Web3.Error or if we should just return a stringy error on `toTask` and `toResult`. The idea was to mimic Elm's HTTP library. The problem is inferring the error case within Web3.js and responding accordingly. More on this later.
